### PR TITLE
[211005] 남윤창

### DIFF
--- a/nyc/211005/baekjoon_14888_insert_operator.py
+++ b/nyc/211005/baekjoon_14888_insert_operator.py
@@ -1,0 +1,36 @@
+import sys
+
+
+def cal(op, a, b):
+    if op == 0:
+        return a + b
+    elif op == 1:
+        return a - b
+    elif op == 2:
+        return a * b
+    else:
+        return -(-a // b) if a < 0 else a // b
+
+
+def recur(max_depth, depth, result):
+    global MAX, MIN
+    if depth == max_depth:
+        MAX = max(result, MAX)
+        MIN = min(result, MIN)
+        return
+
+    for i in range(len(ops)):
+        if ops[i] != 0:
+            ops[i] -= 1
+            recur(max_depth, depth+1, cal(i, result, seq[depth]))
+            ops[i] += 1
+
+
+if __name__ == "__main__":
+    MAX, MIN = -int(1e9), int(1e9)
+    N = int(sys.stdin.readline())
+    seq = list(map(int, sys.stdin.readline().split()))
+    ops = list(map(int, sys.stdin.readline().split()))
+    recur(N, 1, seq[0])
+    print(MAX)
+    print(MIN)

--- a/nyc/211005/baekjoon_16397_escape.py
+++ b/nyc/211005/baekjoon_16397_escape.py
@@ -1,0 +1,46 @@
+import sys
+from collections import deque
+
+
+def button_a(num):
+    return num+1 if num+1 <= 99999 else -1
+
+
+def button_b(num):
+    if num*2 > 99999:
+        return -1
+    if num == 0:
+        return 0
+    str_num = str(num*2)
+    front = int(str_num[0]) - 1
+    return int(str(front) + str_num[1:])
+
+
+def solution(n, t, g):
+    que = deque()
+    que.append([n, 0])
+    visited = {n}
+    while que:
+        num, count = que.popleft()
+        if count > t:
+            break
+
+        if num == g:
+            return count
+
+        nxt = button_a(num)
+        if nxt != -1 and nxt not in visited:
+            visited.add(nxt)
+            que.append([nxt, count+1])
+
+        nxt = button_b(num)
+        if nxt != -1 and nxt not in visited:
+            visited.add(nxt)
+            que.append([nxt, count+1])
+
+    return "ANG"
+
+
+if __name__ == "__main__":
+    N, T, G = map(int, sys.stdin.readline().split())
+    print(solution(N, T, G))

--- a/nyc/211005/baekjoon_2302_theater_seat.py
+++ b/nyc/211005/baekjoon_2302_theater_seat.py
@@ -1,0 +1,27 @@
+import sys
+
+
+def fibonacci(n):
+    for i in range(2, n+1):
+        dp[i] = dp[i-1] + dp[i-2]
+
+
+def solution(n, m):
+    fibonacci(n)
+    answer = 1
+    for i in range(1, m+2):
+        gap = fixed_seat[i] - fixed_seat[i-1] - 1
+        answer *= dp[gap]
+    return answer
+
+
+if __name__ == "__main__":
+    N = int(sys.stdin.readline())
+    M = int(sys.stdin.readline())
+    dp = [1, 1] + [0] * (N-1)
+    fixed_seat = [0]
+    for _ in range(M):
+        fixed_seat.append(int(sys.stdin.readline()))
+    fixed_seat.append(N + 1)
+    print(solution(N, M))
+


### PR DESCRIPTION
### 한 줄 소감
> 확실히 골드 문제는 골드인 이유가 있다.




## 1번 문제 풀이 - BOJ 2302 극장 좌석
### 문제 분석 - DP
이 문제는 극장 좌석인데 VIP 제외 양쪽 한칸씩은 바꿔 앉을 수 있는 문제이고 이 모든 경우의 수를 구해야 한다. 경우의 수는 최대 20억이 나올것만 같은 힌트를 문제에서 준다. 따라서 `O(N)` 으로도 해결 못하는 문제임을 알아낼 수 있다. 따라서 백트래킹? 완탐? 다 불가능하다. 남는건 `DP`

그러면 `DP`를 어떻게 적용해볼까 하는게 문제이다. 일단 VIP는 고정시켜두고 남은 자리를 가지고 싸우는데, 무엇이 중복되는지 확인해보자. 좌석에서 빈 칸(일반 회원의 자리)의 개수 가 중복이 될 수 있겠다. 따라서 빈 칸의 개수를 `DP`를 통해 메모이제이션을 해두면 편하지 않을까?

1칸일때는 바꿀 수 없다 → 1

2칸일때는 → `(1, 2)` or `(2, 1)` → 2

3칸일때는 → `(1, 2, 3), (1, 3, 2), (2, 1, 3)` → 3

4칸일때는 → `(1, 2, 3, 4), (1, 2, 4, 3), (1, 3, 2, 4), (2, 1, 3, 4), (2, 1, 4, 3)` → 5

5칸일때는 → `(1, 2, 3, 4, 5), (1, 2, 3, 5, 4), (1, 2, 4, 3, 5), (1, 3, 2, 4, 5), (1, 3, 2, 5, 4), (2, 1, 3, 4, 5), (2, 1, 3, 5, 4), (2, 1, 4, 3, 5)` → 8

어라 1, 2, 3, 5, 8 어디서 많이 본 숫자이다. 미심쩍으니 몇 번 더 손으로 해보면 규칙이 있다는 것을 알 수 있고 이는 피보나치 수열이다.

### 풀이 방법
이건 직접 손으로 트리를 그려보면 피보나치 수열을 발견할 수 있다. 무슨 문제인지 잘 모르겠으면 직접 손으로 트리를 자신만의 규칙을 갖고 이어나가보자!

1. 극장 좌석 갯수만큼 피보나치 수열을 미리 돌려놓음.
2. 연속된 빈 칸의 개수를 미리 구해둔 배열을 통해 답에 계속 곱해준다.
    1. 시작값은 1
    2. 만약 연속된 칸이 0칸일 경우 0이 되는데 그냥 이건 `gap[0]`을 1로 채워주면 해결된다.

### 포인트
우리가 `DP`를 풀 때는 직관적으로 보이는 경우에는 바로 풀면되고, 안보일 때는 규칙을 세워서 점화식을 도출해내야 한다.

1. 트리를 이용해서 완전 탐색을 손과 연습장을 통해 직접 해보기
2. 1차원 혹은 2차원 테이블을 만들어서 손과 연습장을 통해 다 써보기

결국 다 해봐야 어디가 중복되는지 쉽게 찾을 수 있다. 나는 이 문제의 경우 1의 방법을 통해 규칙을 찾아서 해결할 수 있었다.





## 2번 문제 풀이 - BOJ 16397 탈출
### 문제 분석 - BFS + DP(Memoization)
이 문제는 A버튼을 누르면 1이 증가, B버튼을 누르면 2배 하고 맨 앞자리가 `0`이 아닌 경우 `-1`을 한다. 그리고 값이 `99999`를 넘어가면 안된다.

규칙은 이게 전부이고 `t`회 안에 가장 빨리 목표값 `g`에 도달해야 하는 문제이다. 문제에서 가장 빨리 목표값에 도달해야 한다는 것을 보고 `BFS`를 느껴야 한다. `BFS`는 `length`가 같다면 최단경로 알고리즘이 된다. 버튼을 누르는 횟수를 길이가 1인 `length`로 보고 `BFS`를 적용하면 된다.

그런데 `BFS`를 진행하다보면 값의 중복이 정말 많이 생긴다. 미리 앞서 봤던 숫자면 또 볼 필요가 없다. 따라서 중복 제거를 위해 메모이제이션을 사용해야 하고, 이를 `visited`라는 `set` 자료구조를 이용하여 해결해보자.

### 풀이 방법
1. `deque`로 시작 값 넣어주고 `visited`에도 시작 값 넣어줌
2. `que`가 빌 때까지 `BFS`
    1. `popleft`
    2. 만약 `count`가 제한횟수 `T`를 넘겼다면 종료 → `ANG`
    3. 정답을 찾았다면 종료 → `count` 출력
    4. A, B 버튼 눌러봄 → 결격사유 없으면 `queue`에 `count + 1 `해서 넣음

여기서 결격 사유란 `99999`를 넘었거나, 이미 계산해본 숫자거나(`visited`에 있거나)

### 포인트
- 최소 횟수만에 탈출하고 싶다는것을 보고 BFS를 떠올리는 것
- DP? 메모이제이션? 을 적용할 때 set을 사용하는 것 (시간복잡도 O(1))






## 3번 문제 풀이 - BOJ 14888 연산자 끼워넣기
### 문제 분석 - DFS or 순열
우선 이 문제는 DFS, 재귀, 백트래킹, 순열 떠오르면 성공이다. 엄밀히 말하면 백트래킹은 아니다. 커트 조건이, 연산자 다 쓴 경우인데, 이건 `leaf node`로 봐야할 듯 싶다.

나는 재귀로 풀었고, 백준의 `N과 M` 유형과 매우 유사하다. 다만 사칙연산이 추가된?

### 풀이 방법
1. 입력 받아주고 N ≥ 2 이므로, `depth`를 1, 초기값을 바로 첫 재귀에 넣어주며 시작
2. 재귀 최대 깊이에 도달하면, 최대, 최소 값 구함 → 리턴
3. 아직 최대 깊이가 아니라면 연산자 개수 하나씩 줄여나가며 모든 경우의 수 탐색

### 포인트
포인트는 재귀 실력이다. 재귀 어려워하면 코테 힘들다. 재귀 연습 열심히 해서 기계가 되자!
