### PR TITLE
[211109] 남윤창

### DIFF
--- a/nyc/211109/baekjoon_1105_팔.py
+++ b/nyc/211109/baekjoon_1105_팔.py
@@ -1,0 +1,20 @@
+import sys
+
+
+def solution(left, right):
+    count = 0
+    if len(left) != len(right):
+        return count
+
+    for i in range(len(left)):
+        if left[i] == right[i]:
+            if left[i] == '8':
+                count += 1
+        else:
+            break
+    return count
+
+
+if __name__ == "__main__":
+    L, R = map(str, sys.stdin.readline().split())
+    print(solution(L, R))

--- a/nyc/211109/baekjoon_14938_서강그라운드.java
+++ b/nyc/211109/baekjoon_14938_서강그라운드.java
@@ -1,0 +1,70 @@
+import java.io.*;
+import java.util.*;
+
+
+public class Main {
+    public static void floyd(int n) {
+        for (int k=1; k<=n; k++) {
+            for (int i=1; i<=n; i++) {
+                for(int j=1; j<=n; j++) {
+                    graph[i][j] = Math.min(graph[i][k] + graph[k][j], graph[i][j]);
+                }
+            }
+        }
+    }
+
+    public static int sum(int n, int m, int idx) {
+        int answer = 0;
+        for (int i=1; i<=n; i++) {
+            if (graph[idx][i] <= m) {
+                answer += items[i];
+            }
+        }
+        return answer;
+    }
+
+    public static int solution(int n, int m) {
+        int biggest = 0;
+        floyd(n);
+        for (int i=1; i<=n; i++) {
+            biggest = Math.max(biggest, sum(n, m, i));
+        }
+        return biggest;
+    }
+
+    static int[] items;
+    static int[][] graph;
+    static int INF = 100000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int R = Integer.parseInt(st.nextToken());
+        items = new int[N+1];
+        graph = new int[N+1][N+1];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=1; i<=N; i++) {
+            items[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i=0; i<=N; i++) {
+            for (int j=0; j<=N; j++) {
+                graph[i][j] = INF;
+            }
+            graph[i][i] = 0;
+        }
+
+        for(int i=0; i<R; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int len = Integer.parseInt(st.nextToken());
+            graph[a][b] = len;
+            graph[b][a] = len;
+        }
+
+        System.out.println(solution(N, M));
+    }
+}

--- a/nyc/211109/baekjoon_2512_예산.java
+++ b/nyc/211109/baekjoon_2512_예산.java
@@ -1,0 +1,50 @@
+import java.io.*;
+import java.util.*;
+
+
+public class Main {
+    public static boolean isBudgetOverflow(int upperbound) {
+        int answer = 0;
+        for (Integer e : budgets) {
+            if (e < upperbound) answer += e;
+            else answer += upperbound;
+        }
+        return answer > total;
+    }
+
+    public static int solution() {
+        if (Arrays.stream(budgets).sum() <= total) {
+            return Arrays.stream(budgets).max().getAsInt();
+        }
+
+        int start = 0, end = INF, answer = 0;
+        while (start <= end) {
+            int mid = (start + end) / 2;
+            if (isBudgetOverflow(mid))
+                end = mid - 1;
+            else {
+                answer = mid;
+                start = mid + 1;
+            }
+        }
+        return answer;
+    }
+
+    static int[] budgets;
+    static int total;
+    static int INF = 100000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int N = Integer.parseInt(br.readLine());
+
+        budgets = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<N; i++) {
+            budgets[i] = Integer.parseInt(st.nextToken());
+        }
+        total = Integer.parseInt(br.readLine());
+
+        System.out.println(solution());
+    }
+}


### PR DESCRIPTION
### 한 줄 소감
`이번 숙제는 다양한 알고리즘 기초 같은 느낌. 문제 풀 때 직관적으로 느끼기보단 근거를 가지고 유형을 분석해보면 좋을 듯 합니다`




## 1번 문제 풀이 - BOJ 1105 팔
### 문제 분석 - 그리디
이 문제는 그리디 유형이다. 역시나 최소값을 요구한다. **8이 포함된 개수가 가장 적은 수의 8의 개수**
- 그리디
- DP + BFS 등

인풋은 20억개.
- 이분탐색
- 투 포인터
- 우선순위 큐 등

그러나 이 문제는 딱히 정렬과 관련된게 아니기 떄문에 이분탐색 제거, 우선순위큐도 인풋이 20억개라서 순차탐색이 안되기 때문에 제거, 투포인터는 딱히 적용할 방법이 없으므로 제거.

그래서 그냥 숫자를 전부 탐색할 수 없는 문제임을 빠르게 깨달아야 하고, 그리디 문제라는 것을 깨달아야 한다.


### 풀이 방법
1. L과 R의 길이가 다르면 -> 0 종료
2. L, R의 길이가 같다면 왼쪽부터 순차탐색
    1. `L[i] == R[i] == '8'` 이라면 `count += 1`
    2. `L[i] != R[i]` 라면 그 뒤에는 8이 안나오는게 최소이기 때문에 탐색 종료


### 포인트
이 문제의 포인트는 그리디임을 깨닫고 푸는 것. 그리디는 항상 그리디인지 깨닫는게 젤 어렵다.





## 2번 문제 풀이 - BOJ 14938 서강그라운드
### 문제 분석 - 최단경로(플로이드)
이 문제는 가중치가 있는 그래프 문제이다. 주변 지역을 수색해야 하니 BFS라고 느낄 수 있지만 간선에 가중치가 있기 때문에 사용할 수 없다.
따라서 최단경로 알고리즘들을 떠올려야 한다.
- 다익스트라
- 플로이드

나는 플로이드를 이용해서 풀었다. 왜냐하면
- 시작 노드가 정해져 있지 않음. 즉, 모든 시작 노드에서의 거리를 따져봐야함.
- 노드 개수가 100개 이하임 O(N^3) 가능


### 풀이 방법
1. 입력 잘 받아서 floyd수행
2. 1부터 n 까지 순회
    1. m보다 거리가 짧은 노드의 아이템 개수 합을 구함
    2. 그리디 하게 합의 최댓값 업데이트
3. 반환

### 포인트
이 문제의 포인트는... 플로이드를 떠올리는 것. 내 개인적으로는 자바로 플로이드 처음 풀어봐서 자료구조 선택에 있어서 시간이 좀 걸렸음.






## 3번 문제 풀이 - BOJ 2512 예산
### 문제 분석 - 이분 탐색(파라메트릭 서치)
예산의 상한액을 구해야 한다. 기본적으로 10000 개의 데이터가 있고 최대 각 예산의 최댓값은 10만이다. 만약 상한액을 1원부터 순차탐색하며 구한다고 해보자. 시간복잡도는 다음과 같다.

`10^4 x 10^5 = 10^9`  = 10억?

순차탐색을 하면 안된다는 것을 깨달았으니, `N -> logN`으로 바꾸는 작업이 필요하다. 여기서 상한액을 꼭 순차탐색할 필요가 없음을 깨달아야 하고 이분탐색과 이에 대한 파라메트릭 서치를 적용해서 풀 수 있다.
- 이분탐색 으로 상한액을 정함
- 정한 상한액을 바탕으로 예산을 초과하는지 True, False의 결론을 내리는 파라메트릭 서치 문제로 바꿀 수 있다는 것.

### 풀이 방법
1. 예산을 전부 배정해도 초과하지 않는다면 예산의 최댓값 리턴
2. 초과한다면, 예산을 기준으로 이분 탐색 시작 (`start <= end` 일때까지 반복)
    1. `mid = (start + end) / 2 `
    2. `mid`를 이용하여 파라메트릭 서치 -> 상한액을 기준으로 예산을 배정하면 예산이 초과하는지 검사
    3. 만약 초과한다면 `end = mid -1`
    4. 초과하지 않는다면 `answer = mid`, `start = mid + 1`
   


### 포인트
이 문제는 파라메트릭 서치를 배울 수 있는 기본 문제이다. 이분탐색 유형으로 나오기 가장 기본 유형이라고 생각되니 연습이 꼭 필요한 유형.
